### PR TITLE
genarate license report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
+    }
+    dependencies {
+        classpath "com.smokejumperit.gradle.license:Gradle-License-Report:0.0.2"
     }
 }
 
@@ -10,6 +14,7 @@ apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'maven'
+apply plugin: 'license-report'
 
 sourceCompatibility = 1.7
 group = 'com.sequenceiq'
@@ -108,4 +113,3 @@ class BuildInfoTask extends DefaultTask {
 artifacts {
     archives sourcesJar
 }
-


### PR DESCRIPTION
The ability to gather the dependency (transient as well) license files running the `./gradlew dependencyLicenseReport` task. 

Will generate an index.html in `build/reports/dependency-license` with license information.